### PR TITLE
(RE) 12. Get articles by topic (fix 404 test)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -162,11 +162,11 @@ describe("/api/articles", () => {
       });
   });
 
-  test("GET:400 responds with empty array if topic does not exist", () => {
+  test("GET:404 topic does not exist", () => {
     return request(app)
       .get("/api/articles?topic=invalid")
-      .expect(200)
-      .then(({ body: { articles } }) => expect(articles).toEqual([]));
+      .expect(404)
+      .then(({ body: { message } }) => expect(message).toBe("Topic Not Found"));
   });
 
   test("GET:400 invalid sort_by query", () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -18,7 +18,11 @@ const {
 
 exports.getArticles = (request, response, next) => {
   const { sort_by, order, topic, limit, page } = request.query;
-  fetchArticles(sort_by, order, topic, limit, page)
+  Promise.resolve()
+    .then(() => {
+      if (topic) return doesTopicExist(topic);
+    })
+    .then(() => fetchArticles(sort_by, order, topic, limit, page))
     .then((articles) => Promise.all([articles, countArticles(topic)]))
     .then(([articles, total_count]) => {
       response.status(200).send({ articles, total_count });


### PR DESCRIPTION
- Fix test for GET /api/articles?topic= when topic does not exist
- Update getArticles() controller to properly handle topic query